### PR TITLE
Implemented fake image-class

### DIFF
--- a/pdf.js
+++ b/pdf.js
@@ -1,4 +1,3 @@
-
 var nodeUtil = require("util"),
     nodeEvents = require("events"),
     fs = require('fs'),
@@ -36,6 +35,37 @@ function createScratchCanvas(width, height) { return new PDFCanvas({}, width, he
 
 var PDFJS = {};
 var globalScope = {};
+
+////////////////////////////////start of fake image
+var PDFImage = (function() {
+	'use strict';
+	
+	var _src = '';
+	var _onload = null;
+	
+	this.__defineSetter__("onload", function(val) {
+		_onload = val;
+	});
+	
+	this.__defineGetter__("onload", function() {
+		return _onload;
+	});
+	
+	this.__defineSetter__("src", function(val) {
+		_src = val;
+		if (_onload) _onload();
+	});
+	
+	this.__defineGetter__("src", function() {
+		return _src;
+	});
+});
+
+var Image = PDFImage;
+var window = {};
+window.btoa = function(val) {
+	return (new Buffer(val, 'ascii')).toString('base64');
+};
 
 var _basePath = __dirname + "/pdfjs/";
 var _fileContent = '';


### PR DESCRIPTION
See #7

Since Node is missing a Image DOM-element, we need to implement a fake one. I want to keep it out of the clutter in `pdf2json/pdfjs` (which should be able to be updated independently) so that's why I added it to `pdf2json/pdf.js` directly above the `eval(...)` call.
