### PR TITLE
Use attribute file to add fields to the json

### DIFF
--- a/lib/p2jcmd.js
+++ b/lib/p2jcmd.js
@@ -4,7 +4,8 @@ var fs = require('fs'),
     path = require('path'),
     _ = require('underscore'),
     PFParser = require("../pdfparser"),
-    pkInfo = require('../package.json');
+    pkInfo = require('../package.json'),
+    PTIXmlParser = require('../lib/ptixmlinject');
 
 var optimist = require('optimist')
     .usage('\nUsage: $0 -f|--file [-o|output_dir]')
@@ -15,9 +16,12 @@ var optimist = require('optimist')
     .alias('f', 'file')
     .describe('f', '(required) Full path of input PDF file or a directory to scan for all PDF files. When specifying a PDF file name, it must end with .PDF, otherwise it would be treated as a input directory.\n')
     .alias('o', 'output_dir')
-    .describe('o', '(optional) Full path of output directory, must already exist. Current JSON file in the output folder will be replaced when file name is same.\n');
-
+    .describe('o', '(optional) Full path of output directory, must already exist. Current JSON file in the output folder will be replaced when file name is same.\n')
+    .alias('a', 'attribute_xml_file')
+    .describe('a', '(optional) Full path of the xml file containing attributes for the fields in the PDF.\n');
+    
 var argv = optimist.argv;
+global.ptiParser = new PTIXmlParser();
 
 var PDF2JSONUtil = (function () {
 
@@ -194,11 +198,26 @@ var PDFProcessor = (function () {
 
             var inputStatus = fs.statSync(argv.f);
 
-            if (inputStatus.isFile()) {
-                this.processOneFile();
+            var self = this;
+            
+            //if the user passed in argv.a then we need to parse the xml file then process the -f option
+            if (_.has(argv, 'a')) {
+            	ptiParser.parseXml(argv.a,function(err) {
+            		if (inputStatus.isFile()) {
+            			self.processOneFile();
+            		}
+            		else if (inputStatus.isDirectory()) {
+            			self.processOneDirectory();
+            		}
+            	});
             }
-            else if (inputStatus.isDirectory()) {
-                this.processOneDirectory();
+            else {
+            	if (inputStatus.isFile()) {
+            		this.processOneFile();
+            	}
+                else if (inputStatus.isDirectory()) {
+                	this.processOneDirectory();
+                }
             }
         }
         catch(e) {

--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -8,7 +8,8 @@ var nodeUtil = require("util"),
     PDFField = require('./pdffield.js'),
     PDFAnno = require('./pdfanno.js'),
     Image = require('./pdfimage.js'),
-    pkInfo = require('../package.json');
+    pkInfo = require('../package.json'),
+    PTIXmlParser = require('../lib/ptixmlinject');
 
 var _pdfjsFiles = [
     'core.js',
@@ -132,6 +133,9 @@ var PDFPageParser = (function () {
 
         var self = this;
 
+        var fields = global.ptiParser.getFields(parseInt(self.id) + 1);
+        _.each(fields, _addField, self);
+        
         function pageViewDrawCallback(error) {
             self.renderingState = RenderingStates.FINISHED;
 

--- a/lib/ptixmlinject.js
+++ b/lib/ptixmlinject.js
@@ -99,8 +99,8 @@ var PTIXmlParser = (function () {
 	};
 
 	cls.prototype.getFields = function(pageNum) {
-		console.log("pageNum:" + pageNum);
-		console.log("pageNum:" + ptiPageArray[pageNum]);
+		//console.log("pageNum:" + pageNum);
+		//console.log("pageNum:" + ptiPageArray[pageNum]);
 		return ptiPageArray[pageNum];
 	};
 	return cls;


### PR DESCRIPTION
Use attribute file to add fields to the json.  The client passes in an XML file from PTI using the -a {xml file name}.  The xml attributes will be added to the fields section of the json.
