### PR TITLE
Update readme.md with instructions to install on Ubuntu machines.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,64 @@ To update with latest version:
 To Run in RESTful Web Servie or as Commandline Utility
 * More details can be found at the bottom of this document.
 
+### Install on Ubuntu
+
+For newcomers, make sure to have the binary "node" installed.
+
+```shell
+mdesales@mdesales-quadf-dev64-vm ~/dev/cfp/sp/services/quadf/trunk (master) $  which node
+/usr/sbin/node
+
+mdesales@mdesales-quadf-dev64-vm ~/dev/cfp/sp/services/quadf/trunk (master) $ node --version
+v0.10.22
+```
+
+If you don't have it correctly configured, you will not even get the version output from pdf2json binary:
+
+```
+mdesales@mdesales-quadf-dev64-vm ~/dev/cfp/sp/services/quadf/trunk (master) $ pdf2json -v
+
+```
+
+If the version does not get printed, then you need to properly install nodejs configure your system to properly point to it. Make sure to follow following steps:
+
+* Install nodejs as described in http://stackoverflow.com/a/16303380/433814. You should have the following:
+
+```
+mdesales@mdesales-quadf-dev64-vm ~/dev/cfp/sp/services/quadf/trunk (master) $ nodejs --version
+v0.10.22
+```
+
+* Create a symbolic link from node to nodejs
+
+```
+mdesales@mdesales-quadf-dev64-vm ~/dev/cfp/sp/services/quadf/trunk (master) $ sudo rm -f /usr/sbin/node
+mdesales@mdesales-quadf-dev64-vm ~/dev/cfp/sp/services/quadf/trunk (master) $ sudo ln -s /usr/bin/nodejs /usr/sbin/node
+```
+* Verify the version of node and install 
+
+```
+mdesales@mdesales-quadf-dev64-vm ~/dev/cfp/sp/services/quadf/trunk (master) $ which node
+/usr/sbin/node
+mdesales@mdesales-quadf-dev64-vm ~/dev/cfp/sp/services/quadf/trunk (master) $ node --version
+v0.10.22
+```
+* Proceed with the install of pdf2json as described.
+
+```
+mdesales@mdesales-quadf-dev64-vm ~/dev/cfp/sp/services/quadf/trunk (master) $ sudo npm install -g pdf2json
+npm http GET https://registry.npmjs.org/pdf2json
+npm http 304 https://registry.npmjs.org/pdf2json
+/usr/bin/pdf2json -> /usr/lib/node_modules/pdf2json/bin/pdf2json
+pdf2json@0.6.1 /usr/lib/node_modules/pdf2json
+
+mdesales@mdesales-quadf-dev64-vm ~/dev/cfp/sp/services/quadf/trunk (master) $ which pdf2json 
+/usr/bin/pdf2json
+
+mdesales@mdesales-quadf-dev64-vm ~/dev/cfp/sp/services/quadf/trunk (master) $ pdf2json --version
+0.6.2
+```
+
 ## Code Example
 
 ```javascript


### PR DESCRIPTION
Adding instructions on how to install on Ubuntu machines. Mostly because Ubuntu installs "node" and it does not work and the solution is to install symlink it to the ppa version of "nodejs" instead.
