### PR TITLE
Expose PDF.js getTextContent method via a Content property.

### DIFF
--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -341,6 +341,7 @@ var PDFJSClass = (function () {
                 HLines: pageParser.HLines,
                 VLines: pageParser.VLines,
                 Fills:pageParser.Fills,
+                Content:pdfPage.getTextContent(),
                 Texts: pageParser.Texts,
                 Fields: pageParser.Fields,
                 Boxsets: pageParser.Boxsets


### PR DESCRIPTION
This is a suggested implementation for #19. 

Right now I roll `pdf2json` with a minor modification in the `pdf.js` script.

Thank you for your great work.
