### PR TITLE
Test whether handled character is a symbol

### DIFF
--- a/lib/pdffont.js
+++ b/lib/pdffont.js
@@ -214,7 +214,7 @@ var PDFFont = (function PFPFontClosure() {
         if (!str || str.length !== 1)
             return retVal;
 
-        if (!this.fontObj.isSymbolicFont) {
+        if (!this.fontObj.isSymbolicFont || !this.isSymbol) {
             if (retVal == "C" || retVal == "G") { //prevent symbolic encoding from the client
                 retVal = " " + retVal + " "; //sample: va_ind_760c
             }


### PR DESCRIPTION
I remember that we had a case which required me to add this check in order to get the right output. We used pdf2json to read text from PDFs and there was a case where the text output was wrong without this. Unfortunately I cannot recall which file it was, otherwise I would have added it as test case.
