### PR TITLE
AcroForms :: 'TM' as an alternative field ID

### DIFF
--- a/base/shared/annotation.js
+++ b/base/shared/annotation.js
@@ -316,6 +316,9 @@ var WidgetAnnotation = (function WidgetAnnotationClosure() {
     data.fieldValue = stringToPDFString(
       Util.getInheritableProperty(dict, 'V') || '');
     data.alternativeText = stringToPDFString(dict.get('TU') || '');
+    
+    data.alternativeID = stringToPDFString(dict.get('TM') || '');
+
     data.defaultAppearance = Util.getInheritableProperty(dict, 'DA') || '';
     var fieldType = Util.getInheritableProperty(dict, 'FT');
     data.fieldType = isName(fieldType) ? fieldType.name : '';

--- a/lib/pdfanno.js
+++ b/lib/pdfanno.js
@@ -18,6 +18,8 @@ var PDFAnno = (function PDFAnnoClosure() {
                 else if (key === 'TU') {
                     //radio buttons use the alternative text from the parent
                     item.alternativeText = val;
+                } else if( key == 'TM') {
+                    item.alternativeID   = val;
                 }
             });
         }

--- a/lib/pdffield.js
+++ b/lib/pdffield.js
@@ -133,6 +133,10 @@ var PDFField = (function PDFFieldClosure() {
             anData.TU = field.alternativeText;
         }
 
+        if (field.alternativeID && field.alternativeID.length > 1) {
+            anData.TM = field.alternativeID;
+        }
+
         return _.extend(anData, _getFieldPosition.call(this, field));
     };
 


### PR DESCRIPTION
TM key is used on Form submissions. It's necessary while matching the field ID at backend