### PR TITLE
Remove forced logging from PDFJS's pdf manager and core obj

### DIFF
--- a/base/core/obj.js
+++ b/base/core/obj.js
@@ -1000,7 +1000,6 @@ var XRef = (function XRefClosure() {
         if (e instanceof MissingDataException) {
           throw e;
         }
-        log('(while reading XRef): ' + e);
       }
 
       if (recoveryMode)

--- a/base/core/pdf_manager.js
+++ b/base/core/pdf_manager.js
@@ -101,7 +101,6 @@ var LocalPdfManager = (function LocalPdfManagerClosure() {
       }
       promise.resolve(result);
     } catch (e) {
-      console.log(e.stack);
       promise.reject(e);
     }
     return promise;
@@ -176,7 +175,6 @@ var NetworkPdfManager = (function NetworkPdfManagerClosure() {
       promise.resolve(result);
     } catch(e) {
       if (!(e instanceof MissingDataException)) {
-        console.log(e.stack);
         promise.reject(e);
         return;
       }


### PR DESCRIPTION
Parsing in `recoveryMode` sends stack traces and other info to the console, which can be very annoying and eventually makes the console useless. Turns out all the PDF we're parsing are falling in recovery mode so this is pretty annoying for us.
