### PR TITLE
Additional bold italic detection

### DIFF
--- a/lib/pdffont.js
+++ b/lib/pdffont.js
@@ -215,6 +215,15 @@ let PDFFont = (function PFPFontClosure() {
             this.bold = this.typeName.indexOf("bold") >= 0 || this.typeName.indexOf("black") >= 0;
         }
         this.italic = fontObj.italic; // fix https://github.com/modesty/pdf2json/issues/42
+        // Extended the fix for https://github.com/modesty/pdf2json/issues/42
+        if (!this.italic) {
+            this.italic = this.typeName.indexOf("italic") >= 0 || this.typeName.indexOf("oblique") >= 0;
+        }
+        // Added detection of hybrid dual bolditalic fonts
+        if (((!this.bold) || (!this.italic)) && (this.typeName.indexOf("boldobl") >= 0)) {
+            this.bold = true;
+            this.italic = true;
+        }
 
         let typeName = this.subType;
         if (fontObj.isSerifFont) {
@@ -382,4 +391,3 @@ let PDFFont = (function PFPFontClosure() {
 })();
 
 module.exports = PDFFont;
-


### PR DESCRIPTION
I have updated the code to extend existing fix for issue #42 and added another detection - bolditalic fonts. So, when we don't have bold or italic set, and fonr identifies itself by "boldobl" in it's name, set bold and italic properties of the text.

It is possible that this doesn't cover all possible situations. This fix is made from my own situation where existing bold/italic detection has failed.