### PR TITLE
Add Width to page object to support variable size pages

### DIFF
--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -369,6 +369,7 @@ let PDFJSClass = (function () {
 	                this.pageWidth = pageParser.width;
 
 	            let page = {Height: pageParser.height,
+                    Width: pageParser.width,
 	                HLines: pageParser.HLines,
 	                VLines: pageParser.VLines,
 	                Fills:pageParser.Fills,

--- a/readme.md
+++ b/readme.md
@@ -131,13 +131,14 @@ Current parsed data has four main sub objects to describe the PDF document.
         * Max: default -1;
         * Parent: parent name, default "unknown";
 * 'Pages': array of 'Page' object that describes each page in the PDF, including sizes, lines, fills and texts within the page. More info about 'Page' object can be found at 'Page Object Reference' section
-* 'Width': the PDF page width in page unit
+* 'Width': width of first PDF page in page unit
 
 ### Page object Reference
 
 Each page object within 'Pages' array describes page elements and attributes with 5 main fields:
 
 * 'Height': height of the page in page unit
+* 'Width': width of the page in page unit
 * 'HLines': horizontal line array, each line has 'x', 'y' in relative coordinates for positioning, and 'w' for width, plus 'l' for length. Both width and length are in page unit
 * 'Vline': vertical line array, each line has 'x', 'y' in relative coordinates for positioning, and 'w' for width, plus 'l' for length. Both width and length are in page unit;
     * v0.4.3 added Line color support. Default is 'black', other wise set in 'clr' if found in color dictionary, or 'oc' field if not found in dictionary;


### PR DESCRIPTION
Since not all pages of a PDF need be the same height/width, add a `Width` property to the Page object.