### PR TITLE
add range limited parsing option

### DIFF
--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -252,8 +252,9 @@ let PDFJSClass = (function () {
     };
 
 
-    cls.prototype.parsePDFData = function(arrayBuffer) {
+    cls.prototype.parsePDFData = function(arrayBuffer, range) {
         this.pdfDocument = null;
+        this.range = range;
 
         let parameters = {password: '', data: arrayBuffer};
         PDFJS.getDocument(parameters).then(
@@ -331,7 +332,11 @@ let PDFJSClass = (function () {
 	cls.prototype.loadPages = function() {
 		let pagesCount = this.pdfDocument.numPages;
 		let pagePromises = [];
-		for (let i = 1; i <= pagesCount; i++)
+
+        this.range[0] = this.range[0] || 1;
+        this.range[1] = this.range[1] || pagesCount;
+
+		for (let i = this.range[0]; i <= this.range[1]; i++)
 			pagePromises.push(this.pdfDocument.getPage(i));
 
 		let pagesPromise = PDFJS.Promise.all(pagePromises);
@@ -339,7 +344,7 @@ let PDFJSClass = (function () {
 		nodeUtil.p2jinfo("PDF loaded. pagesCount = " + pagesCount);
 
 		return pagesPromise.then(
-			promisedPages => this.parsePage(promisedPages, 0, 1.5),
+			promisedPages => this.parsePage(promisedPages, this.range[0] - 1, 1.5),
 			error => this.raiseErrorEvent("pagesPromise error: " + error)
 		);
 	};
@@ -347,12 +352,12 @@ let PDFJSClass = (function () {
     cls.prototype.parsePage = function(promisedPages, id, scale) {
         nodeUtil.p2jinfo("start to parse page:" + (id+1));
 
-        let pdfPage = promisedPages[id];
+        let pdfPage = promisedPages[id - (this.range[0] - 1)];
         let pageParser = new PDFPageParser(pdfPage, id, scale, this.ptiParser);
 
         function continueOnNextPage() {
             nodeUtil.p2jinfo("complete parsing page:" + (id+1));
-            if (id === (this.pdfDocument.numPages - 1) ) {
+            if (id === (this.range[1] - 1) ) {
 	            this.raiseReadyEvent({Pages:this.pages, Width: this.pageWidth});
 
 	            //v1.1.2: signal end of parsed data with null

--- a/pdfparser.js
+++ b/pdfparser.js
@@ -43,7 +43,7 @@ let PDFParser = (function () {
 		this.PDFJS.on("pdfjs_parseDataReady", _onPDFJSParseDataReady.bind(this));
 		this.PDFJS.on("pdfjs_parseDataError", _onPDFJSParserDataError.bind(this));
 
-		this.PDFJS.parsePDFData(buffer || _binBuffer[this.pdfFilePath]);
+		this.PDFJS.parsePDFData(buffer || _binBuffer[this.pdfFilePath], this.range);
 	};
 
 	let _processBinaryCache = function() {
@@ -88,7 +88,7 @@ let PDFParser = (function () {
     function PdfParser(context, needRawText) {
 		//call constructor for super class
 	    stream.Transform.call(this, {objectMode: true, bufferSize: 64 * 1024});
-	
+
         // private
         let _id = _nextId++;
 
@@ -130,8 +130,9 @@ let PDFParser = (function () {
 		nodeUtil.verbosity(verbosity || 0);
 	};
 
-	PdfParser.prototype.loadPDF = function(pdfFilePath, verbosity) {
+	PdfParser.prototype.loadPDF = function(pdfFilePath, verbosity, begin, end) {
 		this.setVerbosity(verbosity);
+		this.range = [ begin, end ];
 		nodeUtil.p2jinfo("about to load PDF file " + pdfFilePath);
 
 		this.pdfFilePath = pdfFilePath;


### PR DESCRIPTION
Add a range option for parsing sections of PDFs.

Pass 2 numbers as `begin` and `end`. All page numbers between `begin` and `end`, including `end`.
Example: `5, 10 => 5, 6, 7, 8, 9, 10`

Pass 1 number as then `begin`. All pages starting from `begin` until the end of document.
Example: `5 => 5, 6, 7, ...`