### PR TITLE
Fixed bug on some pdfs with fields

### DIFF
--- a/lib/pdfanno.js
+++ b/lib/pdfanno.js
@@ -112,6 +112,9 @@ let PDFAnno = (function PDFAnnoClosure() {
         if (item.hasOwnProperty('TName'))
             return;
 
+        if(!jsFuncName.split)
+            return;
+
         let vParts = jsFuncName.split('(');
         if (vParts.length !== 2)
             return;


### PR DESCRIPTION
I was getting a `no such function jsFuncName` error on `processFieldAttribute`. This fix solved the issue, and it still processed the fields correctly.