### PR TITLE
Do not fail if url is undefined

### DIFF
--- a/base/shared/annotation.js
+++ b/base/shared/annotation.js
@@ -667,7 +667,7 @@ var LinkAnnotation = (function LinkAnnotationClosure() {
 
   // Lets URLs beginning with 'www.' default to using the 'http://' protocol.
   function addDefaultProtocolToUrl(url) {
-    if (url.indexOf('www.') === 0) {
+    if (url && url.indexOf('www.') === 0) {
       return ('http://' + url);
     }
     return url;


### PR DESCRIPTION
For a specific PDF I have, url is undefined and this line fails (indexOf of undefined), this resolves it.
https://github.com/modesty/pdf2json/issues/158