### PR TITLE
fix(deps): update async to v2.6.1 to remove vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "xmldom": "^0.1.22",
     "lodash": "^4.15.0",
     "optimist": "^0.6.1",
-    "async": "^2.0.1"
+    "async": "^2.6.1"
   },
   "devDependencies": {
   },


### PR DESCRIPTION
There are vulernabilities found in the version of lodash currently used. These issues are detailed here:
https://nodesecurity.io/advisories/577
They are fixed in async version >=2.6.1 (remove lodash)
This update upgrades the version of async to a more secure version.
npm tests passed successfully.