### PR TITLE
Update lodash to 4.17.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,12 +38,11 @@
   },
   "dependencies": {
     "xmldom": "^0.1.22",
-    "lodash": "^4.15.0",
+    "lodash": "^4.17.15",
     "optimist": "^0.6.1",
     "async": "^2.0.1"
   },
-  "devDependencies": {
-  },
+  "devDependencies": {},
   "bundledDependencies": [
     "xmldom",
     "lodash",


### PR DESCRIPTION
A security advisory was released for lodash version <= 4.17.12 https://snyk.io/vuln/SNYK-JS-LODASH-450202.

This patch updates to a version where the issue is fixed.

Ran tests locally and all passing after update.