### PR TITLE
Handle dropdown options with only a name

### DIFF
--- a/lib/pdffield.js
+++ b/lib/pdffield.js
@@ -220,6 +220,9 @@ let PDFField = (function PDFFieldClosure() {
         anData.w -= 0.5; //adjust combobox width
         anData.PL = {V: [], D: []};
         _.each(field.value, function(ele, idx) {
+            if (!Array.isArray(ele)) {
+                ele = [ele, ele];
+            }
             anData.PL.D.push(ele[0]);
             anData.PL.V.push(ele[1]);
         });

--- a/lib/pdffield.js
+++ b/lib/pdffield.js
@@ -220,11 +220,13 @@ let PDFField = (function PDFFieldClosure() {
         anData.w -= 0.5; //adjust combobox width
         anData.PL = {V: [], D: []};
         _.each(field.value, function(ele, idx) {
-            if (!Array.isArray(ele)) {
-                ele = [ele, ele];
+            if (Array.isArray(ele)) {
+                anData.PL.D.push(ele[0]);
+                anData.PL.V.push(ele[1]);
+            } else {
+                anData.PL.D.push(ele);
+                anData.PL.V.push(ele);
             }
-            anData.PL.D.push(ele[0]);
-            anData.PL.V.push(ele[1]);
         });
 		
 		// add field value to the object 


### PR DESCRIPTION
Added a check for dropdown/select options to handle options with only a name string, instead of an array with name and value pairs.

Fixes #214