### PR TITLE
Fix "Callback must be a function" error

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ Or, call directly with buffer:
 
     pdfParser.on("pdfParser_dataError", errData => console.error(errData.parserError) );
     pdfParser.on("pdfParser_dataReady", pdfData => {
-        fs.writeFile("./pdf2json/test/F1040EZ.content.txt", pdfParser.getRawTextContent());
+        fs.writeFile("./pdf2json/test/F1040EZ.content.txt", pdfParser.getRawTextContent(), ()=>{console.log("Done.");});
     });
 
     pdfParser.loadPDF("./pdf2json/test/pdf/fd/form/F1040EZ.pdf");
@@ -78,7 +78,7 @@ Or, call directly with buffer:
 
     pdfParser.on("pdfParser_dataError", errData => console.error(errData.parserError) );
     pdfParser.on("pdfParser_dataReady", pdfData => {
-        fs.writeFile("./pdf2json/test/F1040EZ.fields.json", JSON.stringify(pdfParser.getAllFieldsTypes()));
+        fs.writeFile("./pdf2json/test/F1040EZ.fields.json", JSON.stringify(pdfParser.getAllFieldsTypes()), ()=>{console.log("Done.");});
     });
 
     pdfParser.loadPDF("./pdf2json/test/pdf/fd/form/F1040EZ.pdf");


### PR DESCRIPTION
Fixing "TypeError [ERR_INVALID_CALLBACK]: Callback must be a function. Received undefined". Issues: #169 and #191