### PR TITLE
Warn instead of error when name token longer than spec

### DIFF
--- a/base/core/parser.js
+++ b/base/core/parser.js
@@ -534,9 +534,8 @@ var Lexer = (function LexerClosure() {
           str += String.fromCharCode(ch);
         }
       }
-      if (str.length > 128) {
-        error('Warning: name token is longer than allowed by the spec: ' +
-              str.length);
+      if (str.length > 127) {
+        warn('Name token is longer than allowed by the spec: ' + str.length);
       }
       return new Name(str);
     },


### PR DESCRIPTION
Fixes #217, fixes #210 

These changes were adapted from a recent version of PDF.js which no longer throws an error when the name is too long and instead logs a warning, so the PDF should be able to be parsed.