### PR TITLE
Prevent `Cannot read property 'vertical' of undefined`

### DIFF
--- a/base/display/canvas.js
+++ b/base/display/canvas.js
@@ -1036,7 +1036,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     showText: function CanvasGraphics_showText(glyphs, skipTextSelection) {
       var ctx = this.ctx;
       var current = this.current;
-      var font = current.font;
+      var font = current.font || {};
       var fontSize = current.fontSize;
       var fontSizeScale = current.fontSizeScale;
       var charSpacing = current.charSpacing;


### PR DESCRIPTION
On some documents `CanvasGraphics.showText` can be run prior to `CanvasGraphics.setFont`, thus causing a `TypeError`. This quick hack allows such documents to work.

Fixes modesty/pdf2json#244.