### PR TITLE
Give the checked status of checkboxes, for parsing checkboxes in forms

### DIFF
--- a/base/shared/annotation.js
+++ b/base/shared/annotation.js
@@ -313,8 +313,10 @@ var WidgetAnnotation = (function WidgetAnnotationClosure() {
     var dict = params.dict;
     var data = this.data;
 
-    data.fieldValue = stringToPDFString(
-      Util.getInheritableProperty(dict, 'V') || '');
+    var rawValue = Util.getInheritableProperty(dict, 'V') || '';
+    var value = (rawValue.name ? rawValue.name : rawValue) || '';
+    data.fieldValue = stringToPDFString(value);
+             
     data.alternativeText = stringToPDFString(dict.get('TU') || '');
     
     data.alternativeID = stringToPDFString(dict.get('TM') || '');

--- a/lib/pdffield.js
+++ b/lib/pdffield.js
@@ -150,6 +150,9 @@ class PDFField {
                 TypeInfo: {}
             }
         }, this.#getFieldBaseData(box));
+        if(box.fieldValue) {
+            anData.checked = box.fieldValue !== 'Off';
+          }
 
         this.Boxsets.push({boxes:[anData]});
     }


### PR DESCRIPTION
The value of checkboxes was read within the code, but never given to the user in the final pdf data. This change gives a 'checked' value within boxes.