### PR TITLE
Exclude IDE settings from publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,6 +4,7 @@
 *.DS_Store
 *.swp
 *.out
+.idea
 node_modules/
 target/
 


### PR DESCRIPTION
Hi,

I don't think you should be publishing your jetbrains settings.

Also, may I ask why do you bundle xmldom within the module? Why not keep it as a normal dependency?