### PR TITLE
fix(LabCS-colorspace): createRgbBuffer missing in LabCS colorspace

### DIFF
--- a/base/shared/colorspace.js
+++ b/base/shared/colorspace.js
@@ -870,6 +870,7 @@ var LabCS = (function LabCSClosure() {
     getOutputLength: function LabCS_getOutputLength(inputLength) {
       return inputLength;
     },
+    createRgbBuffer: ColorSpace.prototype.createRgbBuffer,
     isPassthrough: ColorSpace.prototype.isPassthrough,
     isDefaultDecode: function LabCS_isDefaultDecode(decodeMap) {
       // XXX: Decoding is handled with the lab conversion because of the strange


### PR DESCRIPTION
pdf2json doesn't work with pdf in LabCS colorspace, it throws the following error:
```
Warning: Unhandled rejection: TypeError: this.colorSpace.createRgbBuffer is not a function
TypeError: this.colorSpace.createRgbBuffer is not a function
    at PDFImage_fillRgbaBuffer [as fillRgbaBuffer] (eval at <anonymous> (/Users/davidecampagnola/Tutored/pdf2json/lib/pdf.js:62:1), <anonymous>:20964:36)
    at PDFImage_getImageData [as getImageData] (eval at <anonymous> (/Users/davidecampagnola/Tutored/pdf2json/lib/pdf.js:62:1), <anonymous>:21014:12)
    at eval (eval at <anonymous> (/Users/davidecampagnola/Tutored/pdf2json/lib/pdf.js:62:1), <anonymous>:7135:34)
    at Object.eval [as onResolve] (eval at <anonymous> (/Users/davidecampagnola/Tutored/pdf2json/lib/pdf.js:62:1), <anonymous>:20667:7)
    at Object.runHandlers (eval at <anonymous> (/Users/davidecampagnola/Tutored/pdf2json/lib/pdf.js:62:1), <anonymous>:864:35)
    at listOnTimeout (internal/timers.js:554:17)
    at processTimers (internal/timers.js:497:7)
```
there isn't `createRgbBuffer` in the colorspace object
