### PR TITLE
Fixed NO_OPS_RANGE spanning multiple executeOperatorList

### DIFF
--- a/base/display/canvas.js
+++ b/base/display/canvas.js
@@ -406,6 +406,11 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
     this.baseTransform = null;
     this.baseTransformStack = [];
     this.groupLevel = 0;
+
+    //MQZ.Mar.22 Disabled Operators
+    this.opMode = true;
+    this.noOpStartIdx = -1;
+
     if (canvasCtx) {
       addContextCurrentTransform(canvasCtx);
     }
@@ -511,7 +516,7 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
       var fnId;
 
 //MQZ.Mar.22 Disabled Operators
-      var opMode = true, noOpIdx = -1, noOpStartIdx = -1;
+      var noOpIdx = -1;
 
       while (true) {
         if (stepper && i === stepper.nextBreakPoint) {
@@ -524,10 +529,10 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
         if (fnId !== OPS.dependency) {
 //MQZ.Mar.22 Disabled Operators within specified ranages
           noOpIdx = NO_OPS_RANGE.indexOf(fnId);
-          if (opMode) {
+          if (this.opMode) {
              if (noOpIdx >= 0) {
-               opMode = false;
-               noOpStartIdx = noOpIdx;
+               this.opMode = false;
+               this.noOpStartIdx = noOpIdx;
                info("NO_OP Begin: " + this[fnId].name + " - " + i);
              }
              else if (NO_OPS.indexOf(fnId) < 0) {
@@ -535,9 +540,9 @@ var CanvasGraphics = (function CanvasGraphicsClosure() {
              }
           }
           else {
-             if (noOpIdx >= 0 && noOpIdx === (noOpStartIdx+1)) {
-               opMode = true;
-               noOpStartIdx = -1;
+             if (noOpIdx >= 0 && noOpIdx === (this.noOpStartIdx+1)) {
+               this.opMode = true;
+               this.noOpStartIdx = -1;
                info("NO_OP End: " + this[fnId].name + " - " + i);
              }
           }


### PR DESCRIPTION
Fixes #266 

Tracking whether or not we are in a NO_OPS_RANGE on the CanvasGraphics instance instead of only within the current iteration of executeOperatorList() allows the PDF in the issue to parse successfully. Here's the output (with some temporary extra logging) to show the fixed behaviour of "NO_OP" Begin and "NO_OP End" when spanning multiple op lists:
```
Info: start to parse page:18
Info: Skipped: tiny fill: 0 x 0
Info: END OP LIST: - 0
Info: NO_OP Begin: CanvasGraphics_beginAnnotations - 5
Info: END OP LIST: - 100
Info: END OP LIST: - 200
Info: END OP LIST: - 300
Info: END OP LIST: - 400
Info: END OP LIST: - 500
Info: END OP LIST: - 600
Info: END OP LIST: - 700
Info: END OP LIST: - 800
Info: END OP LIST: - 900
Info: NO_OP End: CanvasGraphics_endAnnotations - 968
Info: END OP LIST: - 969
Info: Success: Page 18
Info: complete parsing page:18
Info: PDF parsing completed.
[
  '✓ Success - /Users/craig/Documents/PDFs that break pdf2json/sfn01909.pdf => /Users/craig/Documents/PDFs that break pdf2json/sfn01909.json'
]
1 input files	1 success	0 fail	0 warning
pdf2json@2.0.1 [https://github.com/modesty/pdf2json]: 685.43ms
```

This fix has been used in our production app for a while now and we've had no issues. I also ran the existing tests and everything passed.