### PR TITLE
fix infinite loop in hasBlendModes

### DIFF
--- a/base/core/evaluator.js
+++ b/base/core/evaluator.js
@@ -187,7 +187,11 @@ var PartialEvaluator = (function PartialEvaluatorClosure() {
             continue;
           }
           var xResources = xObject.dict.get('Resources');
-          if (isDict(xResources)) {
+          if (
+            isDict(xResources) && 
+            xResources !== node && 
+            nodes.indexOf(xResources) < 0
+          ) {
             nodes.push(xResources);
           }
         }


### PR DESCRIPTION
don't add resources that are self references or references to nodes that have been seen before to avoid infinite loops