### PR TITLE
nodeUtil imports to point to correct file

### DIFF
--- a/lib/p2jcmd.js
+++ b/lib/p2jcmd.js
@@ -1,4 +1,4 @@
-import nodeUtil from "util";
+import nodeUtil from "../base/shared/util";
 import fs from "fs";
 import path from "path";
 

--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -1,4 +1,4 @@
-import nodeUtil from "util";
+import nodeUtil from "../base/shared/util";
 import fs from "fs";
 import path from 'path';
 import {fileURLToPath} from 'url';

--- a/lib/pdfanno.js
+++ b/lib/pdfanno.js
@@ -1,4 +1,4 @@
-import nodeUtil from "util";
+import nodeUtil from "../base/shared/util";
 
 //BEGIN - MQZ 9/19/2012. Helper functions to parse acroForm elements
 function setupRadioButton(annotation, item) {

--- a/lib/pdfcanvas.js
+++ b/lib/pdfcanvas.js
@@ -1,4 +1,4 @@
-import nodeUtil from "util";
+import nodeUtil from "../base/shared/util";
 import PDFLine from "./pdfline.js";
 import PDFFill from "./pdffill.js";
 import PDFFont from "./pdffont.js";

--- a/lib/pdffield.js
+++ b/lib/pdffield.js
@@ -1,4 +1,4 @@
-import nodeUtil from "util";
+import nodeUtil from "../base/shared/util";
 import PDFUnit from "./pdfunit.js";
 
 const kFBANotOverridable = 0x00000400; // indicates the field is read only by the user

--- a/lib/pdffill.js
+++ b/lib/pdffill.js
@@ -1,4 +1,4 @@
-import nodeUtil from "util";
+import nodeUtil from "../base/shared/util";
 import PDFUnit from "./pdfunit.js";
 
 export default class PDFFill{

--- a/lib/pdffont.js
+++ b/lib/pdffont.js
@@ -1,4 +1,4 @@
-import nodeUtil from "util";
+import nodeUtil from "../base/shared/util";
 import PDFUnit from "./pdfunit.js";
 import {kFontFaces, kFontStyles} from "./pdfconst.js";
 

--- a/lib/pdfline.js
+++ b/lib/pdfline.js
@@ -1,4 +1,4 @@
-import nodeUtil from "util";
+import nodeUtil from "../base/shared/util";
 import PDFUnit from "./pdfunit.js";
 
 export default class PDFLine {

--- a/pdfparser.js
+++ b/pdfparser.js
@@ -1,5 +1,5 @@
 import fs from "fs";
-import nodeUtil from "util";
+import nodeUtil from "./base/shared/util";
 import { readFile } from "fs/promises";
 import { EventEmitter } from "events";
 


### PR DESCRIPTION
Update the nodeUtil imports to point to the `base/shared/util.js` file instead of the node.js native util package.

Resolves some bundling issues with next.js.