### PR TITLE
Update TypeScript Definitions for PDFParser Constructor

### DIFF
--- a/pdfparser.d.ts
+++ b/pdfparser.d.ts
@@ -1,7 +1,7 @@
 import {EventEmitter} from "events";
 
 declare class Pdfparser extends EventEmitter{
-    constructor(context?: any, needRawText?: boolean, password?: string);
+    constructor(context?: any, needRawText?: number, password?: string);
     parseBuffer(buffer: Buffer): void;
     loadPDF(pdfFilePath: string, verbosity?: number):Promise<void>
     createParserStream():ParserStream

--- a/pdfparser.d.ts
+++ b/pdfparser.d.ts
@@ -1,7 +1,7 @@
 import {EventEmitter} from "events";
 
 declare class Pdfparser extends EventEmitter{
-    constructor();
+    constructor(context?: any, needRawText?: boolean, password?: string);
     parseBuffer(buffer: Buffer): void;
     loadPDF(pdfFilePath: string, verbosity?: number):Promise<void>
     createParserStream():ParserStream


### PR DESCRIPTION
Update PDFParser constructor with typed parameters. See my [comment](https://github.com/modesty/pdf2json/issues/273#issuecomment-1662587255) on an issue explaining why this is needed. 