### PR TITLE
feat: use `node:` prefix

### DIFF
--- a/lib/p2jcmd.js
+++ b/lib/p2jcmd.js
@@ -1,6 +1,6 @@
-import nodeUtil from "util";
-import fs from "fs";
-import path from "path";
+import nodeUtil from "node:util";
+import fs from "node:fs";
+import path from "node:path";
 
 import {ParserStream, StringifyStream} from "./parserstream.js";
 import PDFParser from "../pdfparser.js";
@@ -26,11 +26,11 @@ class PDFProcessor {
     inputDir = null;
     inputFile = null;
     inputPath = null;
-    
+
     outputDir = null;
     outputFile = null;
     outputPath = null;
-    
+
     pdfParser = null;
     curCLI = null;
 
@@ -49,11 +49,11 @@ class PDFProcessor {
         this.curCLI = curCLI;
     }
 
-    //private methods	
+    //private methods
 	#generateMergedTextBlocksStream() {
 		return new Promise( (resolve, reject) => {
 			const outputStream = ParserStream.createOutputStream(this.outputPath.replace(".json", ".merged.json"), resolve, reject);
-			this.pdfParser.getMergedTextBlocksStream().pipe(new StringifyStream()).pipe(outputStream);	
+			this.pdfParser.getMergedTextBlocksStream().pipe(new StringifyStream()).pipe(outputStream);
 		});
 	}
 
@@ -89,7 +89,7 @@ class PDFProcessor {
 		this.curCLI.addResultCount();
 		this.#processAdditionalStreams()
 			.then( retVal => resolve(retVal))
-			.catch( err => reject(err) );			
+			.catch( err => reject(err) );
 	}
 
 	#onPrimaryError(err, reject) {
@@ -101,14 +101,14 @@ class PDFProcessor {
 		return new Promise( (resolve, reject) => {
 			this.pdfParser = new PDFParser(null, PROCESS_RAW_TEXT_CONTENT);
 			this.pdfParser.on("pdfParser_dataError", evtData => this.#onPrimaryError(evtData.parserError, reject));
-	
+
 			const outputStream = fs.createWriteStream(this.outputPath);
 			outputStream.on('finish', () => this.#onPrimarySuccess(resolve, reject));
 			outputStream.on('error', err => this.#onPrimaryError(err, reject));
-	
+
 			nodeUtil.p2jinfo("Transcoding Stream " + this.inputFile + " to - " + this.outputPath);
 			const inputStream = fs.createReadStream(this.inputPath, {bufferSize: 64 * 1024});
-			inputStream.pipe(this.pdfParser.createParserStream()).pipe(new StringifyStream()).pipe(outputStream);	
+			inputStream.pipe(this.pdfParser.createParserStream()).pipe(new StringifyStream()).pipe(outputStream);
 		});
 	};
 
@@ -193,7 +193,7 @@ class PDFProcessor {
 			else {
 				const parserFunc = PROCESS_WITH_STREAM ? this.#parseOnePDFStream : this.#parseOnePDF;
 				parserFunc.call(this)
-					.then( value => resolve(value) ) 
+					.then( value => resolve(value) )
 					.catch( err => reject(err) );
 			}
 		});
@@ -201,7 +201,7 @@ class PDFProcessor {
 
     getOutputFile = function() {
         return path.join(this.outputDir, this.outputFile);
-    }   
+    }
 }
 
 export default class PDFCLI {
@@ -220,7 +220,7 @@ export default class PDFCLI {
         this.statusMsgs = [];
     }
 
-    initialize() {        
+    initialize() {
         nodeUtil.verbosity(VERBOSITY_LEVEL);
         let retVal = true;
         try {
@@ -251,31 +251,31 @@ export default class PDFCLI {
 
 		console.log(_PRO_TIMER);
 		console.time(_PRO_TIMER);
-    
+
 		try {
-            const inputStatus = fs.statSync(INPUT_DIR_OR_FILE);			
+            const inputStatus = fs.statSync(INPUT_DIR_OR_FILE);
             if (inputStatus.isFile()) {
 				this.inputCount = 1;
                 await this.processOneFile(path.dirname(INPUT_DIR_OR_FILE), path.basename(INPUT_DIR_OR_FILE));
             }
-            else if (inputStatus.isDirectory()) {				
+            else if (inputStatus.isDirectory()) {
                 await this.processOneDirectory(path.normalize(INPUT_DIR_OR_FILE));
             }
         }
         catch(e) {
-            console.error("Exception: ", e);            
+            console.error("Exception: ", e);
         }
 		finally {
 			this.complete();
 		}
     }
 
-    complete() {        
+    complete() {
         if (this.statusMsgs.length > 0)
             console.log(this.statusMsgs);
-        console.log(`${this.inputCount} input files\t${this.successCount} success\t${this.failedCount} fail\t${this.warningCount} warning`);    
+        console.log(`${this.inputCount} input files\t${this.successCount} success\t${this.failedCount} fail\t${this.warningCount} warning`);
         process.nextTick( () => {
-            console.timeEnd(_PRO_TIMER);            
+            console.timeEnd(_PRO_TIMER);
             // process.exit((this.inputCount === this.successCount) ? 0 : 1);
         });
     }
@@ -284,16 +284,16 @@ export default class PDFCLI {
 		return new Promise((resolve, reject) => {
 			const p2j = new PDFProcessor(inputDir, inputFile, this);
 			p2j.processFile()
-				.then( retVal => {					
-					this.addStatusMsg(null, `${path.join(inputDir, inputFile)} => ${p2j.getOutputFile()}`);	
+				.then( retVal => {
+					this.addStatusMsg(null, `${path.join(inputDir, inputFile)} => ${p2j.getOutputFile()}`);
 					retVal.forEach(ret => this.addStatusMsg(null, `+ ${ret.value}`));
 					resolve(retVal);
 				})
-				.catch(error => {					
-					this.addStatusMsg(error, `${path.join(inputDir, inputFile)} => ${error}`);							
+				.catch(error => {
+					this.addStatusMsg(error, `${path.join(inputDir, inputFile)} => ${error}`);
 					reject(error);
 				})
-				.finally(() => p2j.destroy()); 
+				.finally(() => p2j.destroy());
 		});
     }
 
@@ -304,7 +304,7 @@ export default class PDFCLI {
     }
 
     processOneDirectory(inputDir) {
-		return new Promise((resolve, reject) => {			
+		return new Promise((resolve, reject) => {
 			fs.readdir(inputDir, (err, files) => {
 				if (err) {
 					this.addStatusMsg(true, `[${inputDir}] - ${err.toString()}`);
@@ -317,7 +317,7 @@ export default class PDFCLI {
 					this.inputCount = pdfFiles.length;
 					if (this.inputCount > 0) {
 						this.processFiles(inputDir, pdfFiles)
-							.then( value => resolve(value) ) 
+							.then( value => resolve(value) )
 							.catch( err => reject(err) );
 					}
 					else {
@@ -330,7 +330,7 @@ export default class PDFCLI {
     }
 
     addStatusMsg(error, oneMsg) {
-        this.statusMsgs.push(error ? `✗ Error : ${oneMsg}` : `✓ Success : ${oneMsg}`); 
+        this.statusMsgs.push(error ? `✗ Error : ${oneMsg}` : `✓ Success : ${oneMsg}`);
     }
 
     addResultCount(error) {

--- a/lib/parserstream.js
+++ b/lib/parserstream.js
@@ -1,5 +1,5 @@
-import { Transform, Readable } from "stream";
-import fs from "fs";
+import { Transform, Readable } from "node:stream";
+import fs from "node:fs";
 
 export class ParserStream extends Transform {
     static createContentStream(jsonObj) {
@@ -19,7 +19,7 @@ export class ParserStream extends Transform {
     #pdfParser = null;
     #chunks = [];
     #parsedData = {Pages:[]};
-    #_flush_callback = null; 
+    #_flush_callback = null;
 
     constructor(pdfParser, options) {
         super(options);
@@ -38,7 +38,7 @@ export class ParserStream extends Transform {
                 this.push(this.#parsedData);
                 this.#_flush_callback();
             }
-            else 
+            else
                 this.#parsedData.Pages.push(page);
         });
     }
@@ -57,9 +57,9 @@ export class ParserStream extends Transform {
     _destroy() {
         super.removeAllListeners();
         this.#pdfParser = null;
-        this.#chunks = [];         
+        this.#chunks = [];
     }
-} 
+}
 
 
 export class StringifyStream extends Transform {
@@ -67,7 +67,7 @@ export class StringifyStream extends Transform {
         super(options);
 
         this._readableState.objectMode = false;
-        this._writableState.objectMode = true;    
+        this._writableState.objectMode = true;
     }
 
     _transform(obj, encoding, callback){

--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -1,10 +1,10 @@
-import nodeUtil from 'util';
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import nodeUtil from 'node:util';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-import { EventEmitter } from 'events';
-import { Blob } from 'buffer';
+import { EventEmitter } from 'node:events';
+import { Blob } from 'node:buffer';
 import { DOMParser } from '@xmldom/xmldom';
 
 import PDFCanvas from './pdfcanvas.js';

--- a/lib/pdfanno.js
+++ b/lib/pdfanno.js
@@ -1,4 +1,4 @@
-import nodeUtil from "util";
+import nodeUtil from "node:util";
 
 //BEGIN - MQZ 9/19/2012. Helper functions to parse acroForm elements
 function setupRadioButton(annotation, item) {
@@ -194,5 +194,5 @@ export default class PDFAnno {
         else {
             nodeUtil.p2jwarn("Unknown fieldType: ", item);
         }
-    }   
+    }
 }

--- a/lib/pdfcanvas.js
+++ b/lib/pdfcanvas.js
@@ -1,4 +1,4 @@
-import nodeUtil from 'util';
+import nodeUtil from 'node:util';
 import PDFLine from './pdfline.js';
 import PDFFill from './pdffill.js';
 import PDFFont from './pdffont.js';

--- a/lib/pdffield.js
+++ b/lib/pdffield.js
@@ -1,4 +1,4 @@
-import nodeUtil from "util";
+import nodeUtil from "node:util";
 import PDFUnit from "./pdfunit.js";
 
 const kFBANotOverridable = 0x00000400; // indicates the field is read only by the user
@@ -215,10 +215,10 @@ export default class PDFField {
                 anData.PL.V.push(ele);
             }
         });
-		
-		// add field value to the object 
+
+		// add field value to the object
 		if (field.fieldValue) {
-			anData.V = field.fieldValue; 
+			anData.V = field.fieldValue;
 		}
         this.Fields.push(anData);
     };
@@ -291,7 +291,7 @@ export default class PDFField {
             });
 
             page.Fields.forEach(field => retVal.push(getFieldBase(field)));
-            
+
         });
         return retVal;
     }

--- a/lib/pdffill.js
+++ b/lib/pdffill.js
@@ -1,4 +1,4 @@
-import nodeUtil from "util";
+import nodeUtil from "node:util";
 import PDFUnit from "./pdfunit.js";
 
 export default class PDFFill{

--- a/lib/pdffont.js
+++ b/lib/pdffont.js
@@ -1,4 +1,4 @@
-import nodeUtil from 'util';
+import nodeUtil from 'node:util';
 import PDFUnit from './pdfunit.js';
 import { kFontFaces, kFontStyles } from './pdfconst.js';
 

--- a/lib/pdfline.js
+++ b/lib/pdfline.js
@@ -1,4 +1,4 @@
-import nodeUtil from "util";
+import nodeUtil from "node:util";
 import PDFUnit from "./pdfunit.js";
 
 export default class PDFLine {

--- a/lib/ptixmlinject.js
+++ b/lib/ptixmlinject.js
@@ -1,4 +1,4 @@
-import fs from "fs";
+import fs from "node:fs";
 import { DOMParser } from "@xmldom/xmldom";
 
 export default class PTIXmlParser {
@@ -10,7 +10,7 @@ export default class PTIXmlParser {
         this.xmlData = null;
         this.ptiPageArray = [];
     }
-	
+
 	parseXml(filePath, callback) {
 		fs.readFile(filePath, 'utf8', (err, data) => {
 			if (err) {
@@ -38,12 +38,12 @@ export default class PTIXmlParser {
 					var fontSize = xmlFields[i].getAttribute('fontSize');
 
 					var item = {};
-					
+
 					var rectLeft = parseInt(xPos) - 21; //was 23.5
 					var rectTop = parseInt(yPos) - 20;//was 23
 					var rectRight = parseInt(rectLeft) + parseInt(width) - 4;
 					var rectBottom = parseInt(rectTop) + parseInt(height) - 4;
-					
+
 					item.fieldType="Tx";
 					if (type == "Boolean") {
 						item.fieldType="Btn";
@@ -59,10 +59,10 @@ export default class PTIXmlParser {
 					item.rect = [rectLeft, rectTop, rectRight, rectBottom];;
 
 					fields.push(item);
-					
+
 					this.ptiPageArray[parseInt(page)]=fields;
 				}
-				
+
 			}
 			callback();
 		});

--- a/pdfparser.cjs
+++ b/pdfparser.cjs
@@ -1,15 +1,15 @@
 'use strict';
 
-var fs = require('fs');
-var nodeUtil = require('util');
+var fs = require('node:fs');
+var nodeUtil = require('node:util');
 var promises = require('fs/promises');
-var events = require('events');
-var path = require('path');
-var url = require('url');
-var { Blob } = require('buffer');
+var node_events = require('node:events');
+var path = require('node:path');
+var node_url = require('node:url');
+require('node:buffer');
 var xmldom = require('@xmldom/xmldom');
 var DOMParser = xmldom.DOMParser;
-var stream = require('stream');
+var node_stream = require('node:stream');
 
 var _documentCurrentScript = typeof document !== 'undefined' ? document.currentScript : null;
 const kColors = [
@@ -1523,10 +1523,10 @@ class PDFField {
                 anData.PL.V.push(ele);
             }
         });
-		
-		// add field value to the object 
+
+		// add field value to the object
 		if (field.fieldValue) {
-			anData.V = field.fieldValue; 
+			anData.V = field.fieldValue;
 		}
         this.Fields.push(anData);
     };
@@ -1599,7 +1599,7 @@ class PDFField {
             });
 
             page.Fields.forEach(field => retVal.push(getFieldBase(field)));
-            
+
         });
         return retVal;
     }
@@ -1799,7 +1799,7 @@ class PDFAnno {
         else {
             nodeUtil.p2jwarn("Unknown fieldType: ", item);
         }
-    }   
+    }
 }
 
 class PDFImage {
@@ -1844,7 +1844,7 @@ class PTIXmlParser {
         this.xmlData = null;
         this.ptiPageArray = [];
     }
-	
+
 	parseXml(filePath, callback) {
 		fs.readFile(filePath, 'utf8', (err, data) => {
 			if (err) {
@@ -1872,12 +1872,12 @@ class PTIXmlParser {
 					var fontSize = xmlFields[i].getAttribute('fontSize');
 
 					var item = {};
-					
+
 					var rectLeft = parseInt(xPos) - 21; //was 23.5
 					var rectTop = parseInt(yPos) - 20;//was 23
 					var rectRight = parseInt(rectLeft) + parseInt(width) - 4;
 					var rectBottom = parseInt(rectTop) + parseInt(height) - 4;
-					
+
 					item.fieldType="Tx";
 					if (type == "Boolean") {
 						item.fieldType="Btn";
@@ -1893,10 +1893,10 @@ class PTIXmlParser {
 					item.rect = [rectLeft, rectTop, rectRight, rectBottom];;
 
 					fields.push(item);
-					
+
 					this.ptiPageArray[parseInt(page)]=fields;
 				}
-				
+
 			}
 			callback();
 		});
@@ -1907,13 +1907,13 @@ class PTIXmlParser {
 	}
 }
 
-const __filename$2 = url.fileURLToPath((typeof document === 'undefined' ? require('u' + 'rl').pathToFileURL(__filename).href : (_documentCurrentScript && _documentCurrentScript.src || new URL('pdfparser.cjs', document.baseURI).href)));
+const __filename$2 = node_url.fileURLToPath((typeof document === 'undefined' ? require('u' + 'rl').pathToFileURL(__filename).href : (_documentCurrentScript && _documentCurrentScript.src || new URL('pdfparser.cjs', document.baseURI).href)));
 const __dirname$2 = path.dirname(__filename$2);
 
 const pkInfo = JSON.parse(fs.readFileSync(`${__dirname$2}/package.json`, 'utf8'));
 const _PARSER_SIG = `${pkInfo.name}@${pkInfo.version} [${pkInfo.homepage}]`;
 
-const __filename$1 = url.fileURLToPath((typeof document === 'undefined' ? require('u' + 'rl').pathToFileURL(__filename).href : (_documentCurrentScript && _documentCurrentScript.src || new URL('pdfparser.cjs', document.baseURI).href)));
+const __filename$1 = node_url.fileURLToPath((typeof document === 'undefined' ? require('u' + 'rl').pathToFileURL(__filename).href : (_documentCurrentScript && _documentCurrentScript.src || new URL('pdfparser.cjs', document.baseURI).href)));
 const __dirname$1 = path.dirname(__filename$1);
 
 const _pdfjsFiles = [
@@ -2113,7 +2113,7 @@ class PDFPageParser {
 }
 
 ////////////////////////////////Start of Node.js Module
-class PDFJSClass extends events.EventEmitter {
+class PDFJSClass extends node_events.EventEmitter {
    pdfDocument = null;
    pages = null;
    rawTextContents = null;
@@ -2376,9 +2376,9 @@ class PDFJSClass extends events.EventEmitter {
    }
 }
 
-class ParserStream extends stream.Transform {
+class ParserStream extends node_stream.Transform {
     static createContentStream(jsonObj) {
-		const rStream = new stream.Readable({objectMode: true});
+		const rStream = new node_stream.Readable({objectMode: true});
 		rStream.push(jsonObj);
 		rStream.push(null);
 		return rStream;
@@ -2394,7 +2394,7 @@ class ParserStream extends stream.Transform {
     #pdfParser = null;
     #chunks = [];
     #parsedData = {Pages:[]};
-    #_flush_callback = null; 
+    #_flush_callback = null;
 
     constructor(pdfParser, options) {
         super(options);
@@ -2413,7 +2413,7 @@ class ParserStream extends stream.Transform {
                 this.push(this.#parsedData);
                 this.#_flush_callback();
             }
-            else 
+            else
                 this.#parsedData.Pages.push(page);
         });
     }
@@ -2432,17 +2432,17 @@ class ParserStream extends stream.Transform {
     _destroy() {
         super.removeAllListeners();
         this.#pdfParser = null;
-        this.#chunks = [];         
+        this.#chunks = [];
     }
-} 
+}
 
 
-class StringifyStream extends stream.Transform {
+class StringifyStream extends node_stream.Transform {
     constructor(options) {
         super(options);
 
         this._readableState.objectMode = false;
-        this._writableState.objectMode = true;    
+        this._writableState.objectMode = true;
     }
 
     _transform(obj, encoding, callback){
@@ -2451,77 +2451,104 @@ class StringifyStream extends stream.Transform {
     }
 }
 
-class PDFParser extends events.EventEmitter { // inherit from event emitter
-    //public static
-    static get colorDict() {return kColors; }
+/**
+ * Class representing a PDF Parser.
+ * @extends EventEmitter
+ */
+class PDFParser extends node_events.EventEmitter {
+    /**
+     * Static method to retrieve color dictionary.
+     * @returns {object} Color dictionary
+     */
+    static get colorDict() { return kColors; }
+
+    /**
+     * Static method to retrieve font face dictionary.
+     * @returns {object} Font face dictionary
+     */
     static get fontFaceDict() { return kFontFaces; }
+
+    /**
+     * Static method to retrieve font style dictionary.
+     * @returns {object} Font style dictionary
+     */
     static get fontStyleDict() { return kFontStyles; }
 
-    //private static    
     static #maxBinBufferCount = 10;
     static #binBuffer = {};
 
-    //private 
     #password = "";
-
-    #context = null; // service context object, only used in Web Service project; null in command line
-    
-    #pdfFilePath = null; //current PDF file to load and parse, null means loading/parsing not started
-    #pdfFileMTime = null; // last time the current pdf was modified, used to recognize changes and ignore cache
-    #data = null; //if file read success, data is PDF content; if failed, data is "err" object
+    #context = null; // service context object, only used in Web Service project; null in command line	    #pdfFilePath = null;
+    #pdfFilePath = null; //current PDF file to load and parse, null means loading/parsing not started	    #data = null;
+    #pdfFileMTime = null; // last time the current pdf was modified, used to recognize changes and ignore cache	    #PDFJS = null;
+    #data = null; //if file read success, data is PDF content; if failed, data is "err" object	    #processFieldInfoXML = false;
     #PDFJS = null; //will be initialized in constructor
-    #processFieldInfoXML = false;//disable additional _fieldInfo.xml parsing and merging (do NOT set to true)
+    #processFieldInfoXML = false; //disable additional _fieldInfo.xml parsing and merging (do NOT set to true)
 
-    // constructor
+    /**
+     * PDFParser constructor.
+     * @param {object} context - The context object (only used in Web Service project); null in command line
+     * @param {boolean} needRawText - Whether raw text is needed or not
+     * @param {string} password - The password for PDF file
+	 * @info Private methods accessible using the [funcName].call(this, ...) syntax
+     */
     constructor(context, needRawText, password) {
-        //call constructor for super class
         super();
-    
-        // private
-        // service context object, only used in Web Service project; null in command line
         this.#context = context;
-
-        this.#pdfFilePath = null; //current PDF file to load and parse, null means loading/parsing not started
-        this.#pdfFileMTime = null; // last time the current pdf was modified, used to recognize changes and ignore cache
-        this.#data = null; //if file read success, data is PDF content; if failed, data is "err" object
+        this.#pdfFilePath = null; //current PDF file to load and parse, null means loading/parsing not started	        this.#pdfFileMTime = null;
+        this.#pdfFileMTime = null; // last time the current pdf was modified, used to recognize changes and ignore cache	        this.#data = null;
+        this.#data = null; //if file read success, data is PDF content; if failed, data is "err" object	        this.#processFieldInfoXML = false;
         this.#processFieldInfoXML = false;//disable additional _fieldInfo.xml parsing and merging (do NOT set to true)
 
         this.#PDFJS = new PDFJSClass(needRawText);
         this.#password = password;
-    } 
-    
-	//private methods, needs to invoked by [funcName].call(this, ...)
-	#onPDFJSParseDataReady(data) {
-		if (!data) { //v1.1.2: data===null means end of parsed data
-			nodeUtil.p2jinfo("PDF parsing completed.");
-			this.emit("pdfParser_dataReady", this.#data);
-		}
-		else {
-			this.#data = {...this.#data, ...data};            
-		}
-	}
+    }
 
-	#onPDFJSParserDataError(err) {
-		this.#data = null;
-		this.emit("pdfParser_dataError", {"parserError": err});
-        // this.emit("error", err);
-	}
+    /**
+     * @private
+     * @param {object} data - The parsed data
+     */
+    #onPDFJSParseDataReady(data) {
+        if (!data) {
+            nodeUtil.p2jinfo("PDF parsing completed.");
+            this.emit("pdfParser_dataReady", this.#data);
+        }
+        else {
+            this.#data = { ...this.#data, ...data };
+        }
+    }
 
-	#startParsingPDF(buffer) {
-		this.#data = {};
+    /**
+     * @private
+     * @param {Error} err - The error object
+     */
+    #onPDFJSParserDataError(err) {
+        this.#data = null;
+        this.emit("pdfParser_dataError", { "parserError": err });
+    }
 
-		this.#PDFJS.on("pdfjs_parseDataReady", data => this.#onPDFJSParseDataReady(data));
-		this.#PDFJS.on("pdfjs_parseDataError", err => this.#onPDFJSParserDataError(err));
+    /**
+     * @private
+     * @param {Buffer} buffer - The PDF buffer
+     */
+    #startParsingPDF(buffer) {
+        this.#data = {};
+        this.#PDFJS.on("pdfjs_parseDataReady", data => this.#onPDFJSParseDataReady(data));
+        this.#PDFJS.on("pdfjs_parseDataError", err => this.#onPDFJSParserDataError(err));
 
         //v1.3.0 the following Readable Stream-like events are replacement for the top two custom events
         this.#PDFJS.on("readable", meta => this.emit("readable", meta));
         this.#PDFJS.on("data", data => this.emit("data", data));
-        this.#PDFJS.on("error", err => this.#onPDFJSParserDataError(err));    
+        this.#PDFJS.on("error", err => this.#onPDFJSParserDataError(err));
 
-		this.#PDFJS.parsePDFData(buffer || PDFParser.#binBuffer[this.binBufferKey], this.#password);
-	}
+        this.#PDFJS.parsePDFData(buffer || PDFParser.#binBuffer[this.binBufferKey], this.#password);
+    }
 
-	#processBinaryCache() {
+	/**
+     * @private
+     * @returns {boolean}
+     */
+    #processBinaryCache() {
 		if (this.binBufferKey in PDFParser.#binBuffer) {
 			this.#startParsingPDF();
 			return true;
@@ -2540,15 +2567,31 @@ class PDFParser extends events.EventEmitter { // inherit from event emitter
 		return false;
 	}
 
-    //public getter
+    /**
+     * Getter for #data
+     * @returns {object|null} Data
+     */
     get data() { return this.#data; }
+
+    /**
+     * Getter for binBufferKey
+     * @returns {string} The binBufferKey
+     */
     get binBufferKey() { return this.#pdfFilePath + this.#pdfFileMTime; }
-        
-    //public APIs
+
+    /**
+     * Creates a parser stream
+     * @returns {ParserStream} A new parser stream
+     */
     createParserStream() {
-        return new ParserStream(this, {objectMode: true, bufferSize: 64 * 1024});
+        return new ParserStream(this, { objectMode: true, bufferSize: 64 * 1024 });
     }
 
+	/**
+     * Asynchronously load a PDF from a file path.
+     * @param {string} pdfFilePath - Path of the PDF file
+     * @param {number} verbosity - Verbosity level
+     */
 	async loadPDF(pdfFilePath, verbosity) {
 		nodeUtil.verbosity(verbosity || 0);
 		nodeUtil.p2jinfo("about to load PDF file " + pdfFilePath);
@@ -2563,7 +2606,7 @@ class PDFParser extends events.EventEmitter { // inherit from event emitter
 
             if (this.#processBinaryCache())
                 return;
-        
+
             PDFParser.#binBuffer[this.binBufferKey] = await promises.readFile(pdfFilePath);
             nodeUtil.p2jinfo(`Load OK: ${pdfFilePath}`);
             this.#startParsingPDF();
@@ -2574,21 +2617,56 @@ class PDFParser extends events.EventEmitter { // inherit from event emitter
         }
 	}
 
-	// Introduce a way to directly process buffers without the need to write it to a temporary file
-	parseBuffer(pdfBuffer) {
+    /**
+     * Parse PDF buffer. Introduce a way to directly process buffers without the need to write it to a temporary file
+     * @param {Buffer} pdfBuffer - PDF buffer
+     * @param {number} verbosity - Verbosity level
+     */
+	parseBuffer(pdfBuffer, verbosity) {
+		nodeUtil.verbosity(verbosity || 0);
 		this.#startParsingPDF(pdfBuffer);
 	}
 
-	getRawTextContent() { return this.#PDFJS.getRawTextContent(); }
-	getRawTextContentStream() { return ParserStream.createContentStream(this.getRawTextContent()); }
+    /**
+     * Retrieve raw text content from PDF.
+     * @returns {string} Raw text content
+     */
+    getRawTextContent() { return this.#PDFJS.getRawTextContent(); }
 
-	getAllFieldsTypes() { return this.#PDFJS.getAllFieldsTypes(); };
-	getAllFieldsTypesStream() { return ParserStream.createContentStream(this.getAllFieldsTypes()); }
+    /**
+     * Retrieve raw text content stream.
+     * @returns {Stream} Raw text content stream
+     */
+    getRawTextContentStream() { return ParserStream.createContentStream(this.getRawTextContent()); }
 
-	getMergedTextBlocksIfNeeded() { return this.#PDFJS.getMergedTextBlocksIfNeeded(); }
-	getMergedTextBlocksStream() { return ParserStream.createContentStream(this.getMergedTextBlocksIfNeeded()) }
+    /**
+     * Retrieve all field types.
+     * @returns {object[]} All field types
+     */
+    getAllFieldsTypes() { return this.#PDFJS.getAllFieldsTypes(); }
 
-	destroy() { // invoked with stream transform process		
+    /**
+     * Retrieve all field types stream.
+     * @returns {Stream} All field types stream
+     */
+    getAllFieldsTypesStream() { return ParserStream.createContentStream(this.getAllFieldsTypes()); }
+
+    /**
+     * Retrieve merged text blocks if needed.
+     * @returns {object} Merged text blocks
+     */
+    getMergedTextBlocksIfNeeded() { return this.#PDFJS.getMergedTextBlocksIfNeeded(); }
+
+    /**
+     * Retrieve merged text blocks stream.
+     * @returns {Stream} Merged text blocks stream
+     */
+    getMergedTextBlocksStream() { return ParserStream.createContentStream(this.getMergedTextBlocksIfNeeded()) }
+
+    /**
+     * Destroy the PDFParser instance.
+     */
+	destroy() { // invoked with stream transform process
         super.removeAllListeners();
 
 		//context object will be set in Web Service project, but not in command line utility

--- a/pdfparser.js
+++ b/pdfparser.js
@@ -1,7 +1,7 @@
-import fs from "fs";
-import nodeUtil from "util";
+import fs from "node:fs";
+import nodeUtil from "node:util";
 import { readFile } from "fs/promises";
-import { EventEmitter } from "events";
+import { EventEmitter } from "node:events";
 
 import PDFJS from "./lib/pdf.js";
 import {ParserStream} from "./lib/parserstream.js";
@@ -38,7 +38,7 @@ export default class PDFParser extends EventEmitter {
     #pdfFilePath = null; //current PDF file to load and parse, null means loading/parsing not started	    #data = null;
     #pdfFileMTime = null; // last time the current pdf was modified, used to recognize changes and ignore cache	    #PDFJS = null;
     #data = null; //if file read success, data is PDF content; if failed, data is "err" object	    #processFieldInfoXML = false;
-    #PDFJS = null; //will be initialized in constructor	
+    #PDFJS = null; //will be initialized in constructor
     #processFieldInfoXML = false; //disable additional _fieldInfo.xml parsing and merging (do NOT set to true)
 
     /**
@@ -95,8 +95,8 @@ export default class PDFParser extends EventEmitter {
         //v1.3.0 the following Readable Stream-like events are replacement for the top two custom events
         this.#PDFJS.on("readable", meta => this.emit("readable", meta));
         this.#PDFJS.on("data", data => this.emit("data", data));
-        this.#PDFJS.on("error", err => this.#onPDFJSParserDataError(err));    
-        
+        this.#PDFJS.on("error", err => this.#onPDFJSParserDataError(err));
+
         this.#PDFJS.parsePDFData(buffer || PDFParser.#binBuffer[this.binBufferKey], this.#password);
     }
 
@@ -109,16 +109,16 @@ export default class PDFParser extends EventEmitter {
 			this.#startParsingPDF();
 			return true;
 		}
-		
-		const allKeys = Object.keys(PDFParser.#binBuffer);	
-		if (allKeys.length > PDFParser.#maxBinBufferCount) {	
-			const idx = this.id % PDFParser.#maxBinBufferCount;	
-			const key = allKeys[idx];	
-			PDFParser.#binBuffer[key] = null;	
-			delete PDFParser.#binBuffer[key];	
 
-			nodeUtil.p2jinfo("re-cycled cache for " + key);	
-		}	
+		const allKeys = Object.keys(PDFParser.#binBuffer);
+		if (allKeys.length > PDFParser.#maxBinBufferCount) {
+			const idx = this.id % PDFParser.#maxBinBufferCount;
+			const key = allKeys[idx];
+			PDFParser.#binBuffer[key] = null;
+			delete PDFParser.#binBuffer[key];
+
+			nodeUtil.p2jinfo("re-cycled cache for " + key);
+		}
 
 		return false;
 	}
@@ -162,7 +162,7 @@ export default class PDFParser extends EventEmitter {
 
             if (this.#processBinaryCache())
                 return;
-        
+
             PDFParser.#binBuffer[this.binBufferKey] = await readFile(pdfFilePath);
             nodeUtil.p2jinfo(`Load OK: ${pdfFilePath}`);
             this.#startParsingPDF();
@@ -222,7 +222,7 @@ export default class PDFParser extends EventEmitter {
     /**
      * Destroy the PDFParser instance.
      */
-	destroy() { // invoked with stream transform process		
+	destroy() { // invoked with stream transform process
         super.removeAllListeners();
 
 		//context object will be set in Web Service project, but not in command line utility

--- a/pkinfo.js
+++ b/pkinfo.js
@@ -1,6 +1,6 @@
-import path from 'path';
-import {fileURLToPath} from 'url';
-import fs from "fs";
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import fs from "node:fs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/rollup/addDestructedImports.js
+++ b/rollup/addDestructedImports.js
@@ -1,6 +1,6 @@
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 // Specify the directory where you want to search for pdfparser.cjs


### PR DESCRIPTION
Add `node:` as the prefix to be compatible with the modern JS environment.

Backward compatibility: nodejs 14 and later

Fixes: https://github.com/stackblitz/webcontainer-core/issues/1312, https://github.com/run-llama/LlamaIndexTS/issues/478