### PR TITLE
Fix name for the export of PDF parser

### DIFF
--- a/pdfparser.d.ts
+++ b/pdfparser.d.ts
@@ -129,4 +129,4 @@ export declare interface Box {
     style: number
 }
 
-export default Pdfparser
+export default PDFParser


### PR DESCRIPTION
Fixes compilation error:

```
> tsc

node_modules/pdf2json/pdfparser.d.ts:132:16 - error TS2552: Cannot find name 'Pdfparser'. Did you mean 'PDFParser'?

132 export default Pdfparser
                   ~~~~~~~~~

  node_modules/pdf2json/pdfparser.d.ts:3:15
    3 declare class PDFParser extends EventEmitter{
                    ~~~~~~~~~
    'PDFParser' is declared here.


Found 1 error in node_modules/pdf2json/pdfparser.d.ts:132
```