### PR TITLE
✨  improve detection of bold font

### DIFF
--- a/lib/pdffont.js
+++ b/lib/pdffont.js
@@ -2,7 +2,7 @@ import nodeUtil from 'util';
 import PDFUnit from './pdfunit.js';
 import { kFontFaces, kFontStyles } from './pdfconst.js';
 
-const _boldSubNames = ['bd', 'bold', 'demi', 'black'];
+const _boldSubNames = ['bd', 'bold', 'demi', 'black', 'medi'];
 const _stdFonts = [
    'arial',
    'helvetica',


### PR DESCRIPTION
`WHYXTS+NimbusRomNo9L-Medi` should be in the bolded category

![image](https://github.com/modesty/pdf2json/assets/5390013/b38b46be-475d-4be3-b6fe-6a562b60ec10)

https://github.com/modesty/pdf2json/pull/108#issuecomment-2097646106