### PR TITLE
feat: add commonjs type definition file generation

### DIFF
--- a/rollup/bundle-pdfjs-base.js
+++ b/rollup/bundle-pdfjs-base.js
@@ -80,3 +80,9 @@ if (!fs.existsSync(targetDir)) {
 	fs.mkdirSync(targetDir);
 }
 fs.copyFileSync(path.join(__dirname, "../pdfparser.d.ts"), path.join(targetDir, "pdfparser.d.ts"));
+// .d.cts should have "export =" instead of "export default"
+const typeDefContent = fs.readFileSync(path.join(__dirname, "../pdfparser.d.ts"), "utf8");
+fs.writeFileSync(
+	path.join(targetDir, "pdfparser.d.cts"),
+	typeDefContent.replace("export default", "export =")
+);


### PR DESCRIPTION
Output typescript definition for pdfparser.cjs.

## problem solved by this

If the following compiler options are set, importing pdf2json causes an error if `pdfparser.d.cts` is not present:

- `module: "NodeNext"` and `moduleResolution: "NodeNext"`
- `noImplicitAny: true`

The resulting error is as follows:

```
error TS7016: Could not find a declaration file for module 'example-package'. '/home/naoki/WorkDir/js/modtest/node_modules/pdf2json/dist/pdfparser.cjs' implicitly has an 'any' type.
Try `npm i --save-dev @types/pdf2json` if it exists or add a new declaration (.d.ts) file containing `declare module 'pdf2json';`

import PDFParser from 'pdf2json';
                      ~~~~~~~~~~
```