### PR TITLE
add 'types' to package.json 'exports' root

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
 	"readme": "https://github.com/modesty/pdf2json/blob/master/readme.md",
 	"exports": {
 		".": {
+			"types": "./pdfparser.d.ts",
 			"import": "./dist/pdfparser.js",
 			"require": "./dist/pdfparser.cjs"
 		}


### PR DESCRIPTION
## Overview
When resolving modules with TypeScript via the package.json "exports" spec, the type declaration for this package is currently not resolved properly.

This PR fixes that by including the "types" field under "exports" > ".", and resolving to the existing type declaration file.

## Steps to Reproduce

```sh
mkdir demo
cd demo

# Install Dependencies
npm i pdf2json@3.1.2
npm i typescript@5.6.3

# Configure TypeScript
# - We'll use a modern module resolution strategy, "Bundler", which leverages package.json exports.
# - ES2015 is the minimum target for the Bundler strategy.
echo '{"include":["main.ts"],"compilerOptions":{"target":"ES2015","moduleResolution":"Bundler"}}' >> tsconfig.json

# Create a Failing Example
echo 'import PDFParser from "pdf2json"' >> main.ts

# Run TypeScript
# "--skipLibCheck" ignores any internal issues from our dependencies.
# "--noImplicitAny" will error anything any-typed (no typesafety) in our code.
npx tsc --skipLibCheck --noImplicitAny
```

TypeScript will report,

```
main.ts:1:23 - error TS7016: Could not find a declaration file for module 'pdf2json'. '.../demo/node_modules/pdf2json/dist/pdfparser.js' implicitly has an 'any' type.
  There are types at '.../demo/node_modules/pdf2json/pdfparser.d.ts', but this result could not be resolved when respecting package.json "exports". The 'pdf2json' library may need to update its package.json or typings.

1 import PDFParser from "pdf2json"
                        ~~~~~~~~~~


Found 1 error in main.ts:1
```

## Background Information

- Node Documentation Re: "exports" > ... > "types"
  - https://nodejs.org/api/packages.html#community-conditions-definitions
- TypeScript Documentation Re: "exports" > ... > "types"
  - https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports