### PR TITLE
fix: move package manager version from `engines` to `devEngines`

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,13 @@
 		"build:clean": "rm -rf node_modules && rm -f package-lock.json && npm i && npm run build"
 	},
 	"engines": {
-		"node": ">=20.18.0",
-		"npm": ">=10.8.2"
+		"node": ">=20.18.0"
+	},
+	"devEngines": {
+		"packageManager": {
+			"name": "npm",
+			"version": ">=10.8.2"
+		}
 	},
 	"type": "module",
 	"bin": {


### PR DESCRIPTION
This makes sure that `npm` is only enforced for developers in this repo but once published to npm, consumers can use whatever package manager they wish.

See the docs here:

- https://github.com/openjs-foundation/package-metadata-interoperability-collab-space/blob/main/devengines-field-proposal.md
- https://docs.npmjs.com/cli/v11/configuring-npm/package-json#devengines