### PR TITLE
fix: parseBuffer misreads Buffers that are offset views into a larger ArrayBuffer

### DIFF
--- a/pdfparser.js
+++ b/pdfparser.js
@@ -270,7 +270,7 @@ export default class PDFParser extends EventEmitter {
 		}
 		let pdfBufferParse = pdfBuffer;
 		if (pdfBufferParse.buffer.byteLength !== pdfBufferParse.length) {
-			pdfBufferParse = Buffer.from(pdfBufferParse.buffer, 0, pdfBufferParse.byteLength);
+			pdfBufferParse = Buffer.from(pdfBufferParse.buffer, pdfBufferParse.byteOffset, pdfBufferParse.byteLength);
 		}
 
 		this.#startParsingPDF(pdfBufferParse);


### PR DESCRIPTION
parseBuffer normalizes buffers whose backing ArrayBuffer is larger than the view, but it rebuilds the view from offset 0 instead of the buffer's actual byteOffset. The parser then reads unrelated bytes from the backing store and fails on valid PDFs, typically with Invalid XRef stream header.

This started biting in practice on Node.js ≥ 24.18.0, where Buffer.from(str, 'base64') returns a view into a shared 64 KB pool (byteOffset > 0) for decoded payloads under ~64 KB. Any PDF that arrives base64-encoded (a very common case for API payloads) now fails to parse, on all pdf2json versions through 4.0.3.